### PR TITLE
fix: Handle multipart/form-data in server-proxy

### DIFF
--- a/src/server_proxy/server/server.js
+++ b/src/server_proxy/server/server.js
@@ -135,7 +135,12 @@ app.use('/api-proxy', async (req, res, next) => {
         };
 
         if (['POST', 'PUT', 'PATCH'].includes(req.method.toUpperCase())) {
-            axiosConfig.data = req.body;
+            if (req.headers['content-type'] && req.headers['content-type'].toLowerCase().startsWith('multipart/form-data')) {
+                axiosConfig.data = req;
+                axiosConfig.headers['Content-Length'] = req.headers['content-length'];
+            } else {
+                axiosConfig.data = req.body;
+            }
         }
         // For GET, DELETE, etc., axiosConfig.data will remain undefined, 
         // and axios will not send a request body.
@@ -353,4 +358,3 @@ server.on('upgrade', (request, socket, head) => {
         socket.destroy();
     }
 });
-


### PR DESCRIPTION
This PR fixes issue #8.

The server-proxy was failing to handle requests from non-Chromium browsers because they would send `multipart/form-data` requests when an image was included in the `generateContent` call. This change adds the necessary logic to detect and stream these requests correctly.

This makes the proxy more robust by ensuring that requests are forwarded correctly, regardless of the browser being used.